### PR TITLE
Appveyor artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,12 +17,17 @@ version: 1.0.{build}
 # Build worker image (VM template)
 image: Visual Studio 2017
 
+skip_tags: true
+branches:
+  only:
+  - master
+
 environment:
   DeployExtension: false
   Package: true
 
 cache:
-  - packages -> **\packages.config
+- packages -> **\packages.config
 
 configuration: Release
 
@@ -43,12 +48,14 @@ build:
 
 test:
   assemblies:
-    - '**\*tests.dll'
+  - '**\*tests.dll'
 
 #---------------------------------#
 #     artifact configuration      #
 #---------------------------------#
 
 artifacts:
-  - path: 'bin\**\Microsoft.VisualStudio.SlowCheetah*.nupkg'
-  - path: 'bin\**\Microsoft.VisualStudio.SlowCheetah*.vsix'
+- path: 'bin\**\Microsoft.VisualStudio.SlowCheetah*.nupkg'
+  name: Nuget Package
+- path: 'bin\**\Microsoft.VisualStudio.SlowCheetah*.vsix'
+  name: VSIX Package

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,3 @@ test:
 artifacts:
   - path: 'bin\**\Microsoft.VisualStudio.SlowCheetah*.nupkg'
   - path: 'bin\**\Microsoft.VisualStudio.SlowCheetah*.vsix'
-  - path: 'bin\**\Microsoft.VisualStudio.SlowCheetah*.dll'
-  - path: 'bin\**\Microsoft.VisualStudio.SlowCheetah*.pdb'
-  - path: 'bin\**\Microsoft.VisualStudio.SlowCheetah*.targets'


### PR DESCRIPTION
We don't need appveyor to hold onto all the dlls, pdbs, and targets. They only need to be archived on builds we intent to release, which is now done in vsts.