### PR TITLE
Workaround vsix output groups. Vsix no longer loads as .netcore

### DIFF
--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Directory.Build.targets
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Directory.Build.targets
@@ -1,3 +1,12 @@
 <Project>
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />
+
+  <!-- The VSSDK immplements these targets. Since their name ends with OutputGroup,
+       these targets get run during design time builds per convention. If the Project
+       is not a VSIX project and sets $CreateVSIXContainer=false these targets should be 
+       a no-op. However they dont check for that and that's a bug. To workaround, we override them
+       with empty targets and conditionally import these if CreateVSIXContainer is false.
+       Tracked by https://devdiv.visualstudio.com/DevDiv/_workitems?id=365685&fullScreen=false&_a=edit -->
+  <Target Name="VSIXIdentifierProjectOutputGroup" />
+  <Target Name="VSIXNameProjectOutputGroup" />
 </Project>

--- a/src/Microsoft.VisualStudio.SlowCheetah.Vsix/Microsoft.VisualStudio.SlowCheetah.Vsix.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.Vsix/Microsoft.VisualStudio.SlowCheetah.Vsix.csproj
@@ -26,8 +26,7 @@
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net45</TargetFramework>
-    <OutputPath>$(OutputPath)$(TargetFramework)\</OutputPath>
+    <OutputPath>$(OutputPath)net45\</OutputPath>
     <TargetName>Microsoft.VisualStudio.SlowCheetah</TargetName>
     <IsProductComponent>true</IsProductComponent>
   </PropertyGroup>


### PR DESCRIPTION
1. Fix a design time error due to the vsix output groups.
2. Stop loading the vsix package in .netcore for now.