### PR TITLE
Link to Microsoft.VisualStudio.SlowCheetah instead to the original SlowCheetah nuget package

### DIFF
--- a/doc/transforming_files.md
+++ b/doc/transforming_files.md
@@ -3,7 +3,7 @@
 ## Summary
 The [SlowCheetah Visual Studio extension](https://marketplace.visualstudio.com/items?itemName=WillBuikMSFT.SlowCheetah-XMLTransforms) allows you to add and preview transformation to files in your project.
 
-The [SlowCheetah NuGet package](https://www.nuget.org/packages/SlowCheetah/) is required for build-time transformations, which are discussed in more detail below.
+The [Microsoft.VisualStudio.SlowCheetah NuGet package](https://www.nuget.org/packages/Microsoft.VisualStudio.SlowCheetah) is required for build-time transformations, which are discussed in more detail below.
 
 ## Getting Started
 


### PR DESCRIPTION
As far as I understand, `Microsoft.VisualStudio.SlowCheetah` is the most up to date and recommended package, so link to this one instead to the original `SlowCheetah`.