### PR TITLE
Make Microsoft.VisualStudio.SlowCheetah package a development-only dependency

### DIFF
--- a/src/Microsoft.VisualStudio.SlowCheetah/Microsoft.VisualStudio.SlowCheetah.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah/Microsoft.VisualStudio.SlowCheetah.csproj
@@ -18,6 +18,8 @@
      <RepositoryUrl>https://github.com/Microsoft/slow-cheetah</RepositoryUrl>
      <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
      <IsTool>true</IsTool>
+     <DevelopmentDependency>true</DevelopmentDependency>
+     <MinClientVersion>2.8</MinClientVersion>
   </PropertyGroup>
   
   <!-- Additional files for the nupkg -->


### PR DESCRIPTION
Marks the Microsoft.VisualStudio.SlowCheetah package as a development-only dependency, and sets its minimum client version to 2.8 as recommended by the NuGet docs for using the development-only dependency feature.

Resolves #113.