### PR TITLE
Preview non build configs for nested files

### DIFF
--- a/doc/transforming_files.md
+++ b/doc/transforming_files.md
@@ -1,9 +1,9 @@
 # Transforming Files with SlowCheetah
 
 ## Summary
-The [SlowCheetah Visual Studio extension](https://marketplace.visualstudio.com/items?itemName=WillBuikMSFT.SlowCheetah-XMLTransforms) allows you to add and preview transformation to files in your project.
+The [SlowCheetah Visual Studio extension](https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.SlowCheetah-XMLTransforms) allows you to add and preview transformation to files in your project.
 
-The [SlowCheetah NuGet package](https://www.nuget.org/packages/SlowCheetah/) is required for build-time transformations, which are discussed in more detail below.
+The [SlowCheetah NuGet package](https://www.nuget.org/packages/Microsoft.VisualStudio.SlowCheetah) is required for build-time transformations, which are discussed in more detail below.
 
 ## Getting Started
 

--- a/src/Microsoft.VisualStudio.SlowCheetah.Tests/Microsoft.VisualStudio.SlowCheetah.Tests.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.Tests/Microsoft.VisualStudio.SlowCheetah.Tests.csproj
@@ -14,8 +14,8 @@
   <ItemGroup>
     <PackageReference Include="MicroBuild.NonShipping" Version="2.0.40" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.30" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.SlowCheetah.Tests/Microsoft.VisualStudio.SlowCheetah.Tests.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.Tests/Microsoft.VisualStudio.SlowCheetah.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MicroBuild.NonShipping" Version="2.0.40" />
+    <PackageReference Include="MicroBuild.NonShipping" Version="2.0.54" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS.Tests/Microsoft.VisualStudio.SlowCheetah.VS.Tests.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS.Tests/Microsoft.VisualStudio.SlowCheetah.VS.Tests.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <PackageReference Include="MicroBuild.NonShipping" Version="2.0.40" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.30" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS.Tests/Microsoft.VisualStudio.SlowCheetah.VS.Tests.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS.Tests/Microsoft.VisualStudio.SlowCheetah.VS.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MicroBuild.NonShipping" Version="2.0.40" />
+    <PackageReference Include="MicroBuild.NonShipping" Version="2.0.54" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS.Tests/PackageUtilitiesTest.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS.Tests/PackageUtilitiesTest.cs
@@ -106,9 +106,25 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS.Tests
         [InlineData("App.config", "App.config")]
         [InlineData("App.Debug.config", "App.Debug.config")]
         [InlineData("App.config", "App..config")]
+        [InlineData("App.Debug.config", "App.config")]
+        [InlineData("App.config", "App.config.Debug")]
         public void IsFileGenericTransformWithInvalidArguments(string docName, string trnName)
         {
             Assert.False(PackageUtilities.IsGenericFileTransform(docName, trnName));
+        }
+
+        /// <summary>
+        /// Tests <see cref="PackageUtilities.IsGenericFileTransform(string, string)"/> with valid arguments
+        /// </summary>
+        /// <param name="docName">Document name</param>
+        /// <param name="trnName">Tranform file name</param>
+        [Theory]
+        [InlineData("App.config", "App.Debug.config")]
+        [InlineData("App.config", "App.Test.Debug.config")]
+        [InlineData("App.Test.config", "App.Test.Debug.config")]
+        public void IsFileGenericTransformWithValidArguments(string docName, string trnName)
+        {
+            Assert.True(PackageUtilities.IsGenericFileTransform(docName, trnName));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS.Tests/PackageUtilitiesTest.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS.Tests/PackageUtilitiesTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS.Tests
         private IEnumerable<string> testProjectConfigsWithDots = new List<string>(new string[] { "Debug", "Debug.Test", "Release", "Test.Release", "Test.Rel" });
 
         /// <summary>
-        /// Tests <see cref="PackageUtilities.IsFileTransform(string, string, IEnumerable{string})"/> returns on arguments that are null or empty strings
+        /// Tests <see cref="PackageUtilities.IsFileTransformForBuildConfiguration(string, string, IEnumerable{string})"/> returns on arguments that are null or empty strings
         /// </summary>
         /// <param name="docName">Document name</param>
         /// <param name="trnName">Tranform file name</param>
@@ -28,11 +28,11 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS.Tests
         [InlineData("", "App.Debug.config")]
         public void IsFileTransfromWithNullArguments(string docName, string trnName)
         {
-            Assert.False(PackageUtilities.IsFileTransform(docName, trnName, this.baseTestProjectConfigs));
+            Assert.False(PackageUtilities.IsFileTransformForBuildConfiguration(docName, trnName, this.baseTestProjectConfigs));
         }
 
         /// <summary>
-        /// Tests <see cref="PackageUtilities.IsFileTransform(string, string, IEnumerable{string})"/> with valid arguments normally found in projects.
+        /// Tests <see cref="PackageUtilities.IsFileTransformForBuildConfiguration(string, string, IEnumerable{string})"/> with valid arguments normally found in projects.
         /// </summary>
         /// <param name="docName">Document name</param>
         /// <param name="trnName">Tranform file name</param>
@@ -43,11 +43,11 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS.Tests
         [InlineData("App.Test.config", "App.Test.Debug.config")]
         public void IsFileTransfromWithValidArguments(string docName, string trnName)
         {
-            Assert.True(PackageUtilities.IsFileTransform(docName, trnName, this.baseTestProjectConfigs));
+            Assert.True(PackageUtilities.IsFileTransformForBuildConfiguration(docName, trnName, this.baseTestProjectConfigs));
         }
 
         /// <summary>
-        /// Tests <see cref="PackageUtilities.IsFileTransform(string, string, IEnumerable{string})"/> with invalid arguments
+        /// Tests <see cref="PackageUtilities.IsFileTransformForBuildConfiguration(string, string, IEnumerable{string})"/> with invalid arguments
         /// </summary>
         /// <param name="docName">Document name</param>
         /// <param name="trnName">Tranform file name</param>
@@ -57,11 +57,11 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS.Tests
         [InlineData("App.Debug.config", "App.Release.config")]
         public void IsFileTransfromWithInvalidArguments(string docName, string trnName)
         {
-            Assert.False(PackageUtilities.IsFileTransform(docName, trnName, this.baseTestProjectConfigs));
+            Assert.False(PackageUtilities.IsFileTransformForBuildConfiguration(docName, trnName, this.baseTestProjectConfigs));
         }
 
         /// <summary>
-        /// Tests <see cref="PackageUtilities.IsFileTransform(string, string, IEnumerable{string})"/> with project configurations containing dots
+        /// Tests <see cref="PackageUtilities.IsFileTransformForBuildConfiguration(string, string, IEnumerable{string})"/> with project configurations containing dots
         /// and file names with similar structures. Tests valid names
         /// </summary>
         /// <param name="docName">Document name</param>
@@ -75,11 +75,11 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS.Tests
         [InlineData("App.config", "App.Test.Rel.config")]
         public void IsFileTransformWithDottedConfigsAndValidNames(string docName, string trnName)
         {
-            Assert.True(PackageUtilities.IsFileTransform(docName, trnName, this.testProjectConfigsWithDots));
+            Assert.True(PackageUtilities.IsFileTransformForBuildConfiguration(docName, trnName, this.testProjectConfigsWithDots));
         }
 
         /// <summary>
-        /// Tests <see cref="PackageUtilities.IsFileTransform(string, string, IEnumerable{string})"/> with project configurations containing dots
+        /// Tests <see cref="PackageUtilities.IsFileTransformForBuildConfiguration(string, string, IEnumerable{string})"/> with project configurations containing dots
         /// and file names with similar structures. Tests invalid names
         /// </summary>
         /// <param name="docName">Document name</param>
@@ -94,7 +94,21 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS.Tests
         [InlineData("App.Test.Rel.config", "App.Test.Rel.config")]
         public void IsFileTransformWithDottedConfigsAndInvalidNames(string docName, string trnName)
         {
-            Assert.False(PackageUtilities.IsFileTransform(docName, trnName, this.testProjectConfigsWithDots));
+            Assert.False(PackageUtilities.IsFileTransformForBuildConfiguration(docName, trnName, this.testProjectConfigsWithDots));
+        }
+
+        /// <summary>
+        /// Tests <see cref="PackageUtilities.IsGenericFileTransform(string, string)"/> with invalid arguments
+        /// </summary>
+        /// <param name="docName">Document name</param>
+        /// <param name="trnName">Tranform file name</param>
+        [Theory]
+        [InlineData("App.config", "App.config")]
+        [InlineData("App.Debug.config", "App.Debug.config")]
+        [InlineData("App.config", "App..config")]
+        public void IsFileGenericTransformWithInvalidArguments(string docName, string trnName)
+        {
+            Assert.False(PackageUtilities.IsGenericFileTransform(docName, trnName));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Microsoft.VisualStudio.SlowCheetah.VS.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Microsoft.VisualStudio.SlowCheetah.VS.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="EnvDTE" Version="8.0.1" />
-    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.40" />
+    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.54" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="14.0.25424" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="14.1.2" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.14.0" Version="14.0.23205" />

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Package/PreviewTransformCommand.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Package/PreviewTransformCommand.cs
@@ -298,7 +298,8 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
             }
 
             // Start by checking if the parent is the source file
-            if (PackageUtilities.IsFileTransform(Path.GetFileName(documentPath), transformName, configs))
+            // Here, we can do a generic transform file test to allow for transformations that aren't associated with build configurations
+            if (PackageUtilities.IsGenericFileTransform(Path.GetFileName(documentPath), transformName))
             {
                 docId = parentId;
                 return true;
@@ -317,7 +318,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
                 }
 
                 if (PackageUtilities.IsPathValid(documentPath)
-                    && PackageUtilities.IsFileTransform(Path.GetFileName(documentPath), transformName, configs))
+                    && PackageUtilities.IsFileTransformForBuildConfiguration(Path.GetFileName(documentPath), transformName, configs))
                 {
                     return true;
                 }
@@ -330,7 +331,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
                         docId = (uint)(int)childIdObj;
                         if (ErrorHandler.Succeeded(project.GetMkDocument(docId, out documentPath))
                             && PackageUtilities.IsPathValid(documentPath)
-                            && PackageUtilities.IsFileTransform(Path.GetFileName(documentPath), transformName, configs))
+                            && PackageUtilities.IsFileTransformForBuildConfiguration(Path.GetFileName(documentPath), transformName, configs))
                         {
                             return true;
                         }

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/SlowCheetahPackage.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/SlowCheetahPackage.cs
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
             IEnumerable<string> configs = ProjectUtilities.GetProjectConfigurations(vsProject as IVsHierarchy);
 
             // If the project is a web app, check for the Web.config files added by default
-            return ProjectUtilities.IsProjectWebApp(vsProject) && PackageUtilities.IsFileTransform("web.config", Path.GetFileName(filePath), configs);
+            return ProjectUtilities.IsProjectWebApp(vsProject) && PackageUtilities.IsFileTransformForBuildConfiguration("web.config", Path.GetFileName(filePath), configs);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Utilities/PackageUtilities.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Utilities/PackageUtilities.cs
@@ -148,7 +148,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         /// <returns>True if the names correspond to compatible transformation files</returns>
         public static bool IsGenericFileTransform(string documentName, string transformName)
         {
-            return TryGetFileTransform(documentName, transformName, out string config);
+            return TryGetFileTransform(documentName, transformName, out _);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.SlowCheetah.Vsix/Microsoft.VisualStudio.SlowCheetah.Vsix.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.Vsix/Microsoft.VisualStudio.SlowCheetah.Vsix.csproj
@@ -68,7 +68,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.40" />
+    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.54" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.1.192" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.30" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.SlowCheetah/Microsoft.VisualStudio.SlowCheetah.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah/Microsoft.VisualStudio.SlowCheetah.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.40" />
+    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.54" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="14.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Jdt" Version="0.9.23" />
     <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.1" />


### PR DESCRIPTION
If the parent of the transformation file has the appropriate name, we should consider it as a source file for previewing the transformation, even if it is not associated with a build configuration.

Fixes #98 and other associated issues.

Also update packages to fix tests and appveyor build.