### PR TITLE
Fix case-sensitive GUID check

### DIFF
--- a/src/Microsoft.VisualStudio.SlowCheetah/Build/Microsoft.VisualStudio.SlowCheetah.Web.targets
+++ b/src/Microsoft.VisualStudio.SlowCheetah/Build/Microsoft.VisualStudio.SlowCheetah.Web.targets
@@ -12,7 +12,7 @@ Copyright (C) Sayed Ibrahim Hashimi, Chuck England 2011-2013. All rights reserve
   <PropertyGroup>
     <!-- Determines if the project is web -->
     <WapProjectTypeGuid>349c5851-65df-11da-9384-00065b846f21</WapProjectTypeGuid>
-    <ScIsWap Condition="'$(ScIsWap)' == '' and '$(WapProjectTypeGuid)' != '' and '$(ProjectTypeGuids)' != ''">$(ProjectTypeGuids.Contains($(WapProjectTypeGuid)))</ScIsWap>
+    <ScIsWap Condition="'$(ScIsWap)' == '' and '$(WapProjectTypeGuid)' != '' and '$(ProjectTypeGuids)' != ''">$(ProjectTypeGuids.ToLower().Contains($(WapProjectTypeGuid)))</ScIsWap>
     <ScIsWap Condition="'$(ScIsWap)' == ''">false"</ScIsWap>
   </PropertyGroup>
 


### PR DESCRIPTION
If the project somehow has an uppercase GUID, the targets do not correctly identify it. The way I found to deal with it was to set the `ProjectTypeGuids` to lower when checking for the web app GUID.