### PR TITLE
Fix IsProjectWebApp for VSIX

### DIFF
--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Resources/Guids.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Resources/Guids.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         /// <summary>
         /// Guid string of a Web Application project
         /// </summary>
-        public static readonly Guid GuidWebApplicationString = new Guid("349c5851-65df-11da-9384-00065b846f21");
+        public const string GuidWebApplicationString = "{349c5851-65df-11da-9384-00065b846f21}";
 
         /// <summary>
         /// Guid string for the SlowCheetah Visual Studio Package
@@ -34,5 +34,10 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         /// Guid for the SlowCheetah commands
         /// </summary>
         public static readonly Guid GuidSlowCheetahCmdSet = new Guid(GuidSlowCheetahCmdSetString);
+
+        /// <summary>
+        /// Guid of a Web Application project
+        /// </summary>
+        public static readonly Guid GuidWebApplication = new Guid(GuidWebApplicationString);
     }
 }

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Resources/Guids.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Resources/Guids.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         /// <summary>
         /// Guid string of a Web Application project
         /// </summary>
-        public const string GuidWebApplicationString = "{349c5851-65df-11da-9384-00065b846f21}";
+        public static readonly Guid GuidWebApplicationString = new Guid("349c5851-65df-11da-9384-00065b846f21");
 
         /// <summary>
         /// Guid string for the SlowCheetah Visual Studio Package

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Utilities/ProjectUtilities.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Utilities/ProjectUtilities.cs
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
             {
                 aggregatableProject.GetAggregateProjectTypeGuids(out string projectTypeGuids);
                 List<string> guids = new List<string>(projectTypeGuids.Split(';'));
-                return guids.Contains(Guids.GuidWebApplicationString);
+                return guids.Any(x => new Guid(x) == new Guid(Guids.GuidWebApplicationString));
             }
 
             return false;

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Utilities/ProjectUtilities.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Utilities/ProjectUtilities.cs
@@ -10,6 +10,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Runtime.InteropServices;
     using EnvDTE;
     using Microsoft.VisualStudio;
@@ -187,8 +188,11 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
             if (project is IVsAggregatableProject aggregatableProject)
             {
                 aggregatableProject.GetAggregateProjectTypeGuids(out string projectTypeGuids);
-                List<string> guids = new List<string>(projectTypeGuids.Split(';'));
-                return guids.Any(x => new Guid(x) == new Guid(Guids.GuidWebApplicationString));
+                var guidRegex = new System.Text.RegularExpressions.Regex(@"[0-9A-F]{8}[-]?([0-9A-F]{4}[-]?){3}[0-9A-F]{12}", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+                return projectTypeGuids.Split(';')
+                                       .Where(x => guidRegex.Match(x).Success)
+                                       .Select(x => new Guid(guidRegex.Matches(x)[0].Value))
+                                       .Any(x => x == Guids.GuidWebApplicationString);
             }
 
             return false;

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Utilities/ProjectUtilities.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Utilities/ProjectUtilities.cs
@@ -187,12 +187,23 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         {
             if (project is IVsAggregatableProject aggregatableProject)
             {
-                aggregatableProject.GetAggregateProjectTypeGuids(out string projectTypeGuids);
-                var guidRegex = new System.Text.RegularExpressions.Regex(@"[0-9A-F]{8}[-]?([0-9A-F]{4}[-]?){3}[0-9A-F]{12}", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-                return projectTypeGuids.Split(';')
-                                       .Where(x => guidRegex.Match(x).Success)
-                                       .Select(x => new Guid(guidRegex.Matches(x)[0].Value))
-                                       .Any(x => x == Guids.GuidWebApplicationString);
+                aggregatableProject.GetAggregateProjectTypeGuids(out string projectTypeGuidStrings);
+                var projectTypeGuids = new List<Guid>();
+                foreach (string gs in projectTypeGuidStrings.Split(';'))
+                {
+                    try
+                    {
+                        var guid = new Guid(gs);
+
+                        projectTypeGuids.Add(guid);
+                    }
+                    catch
+                    {
+                        // Don't add to list of guids
+                    }
+                }
+
+                return projectTypeGuids.Contains(Guids.GuidWebApplication);
             }
 
             return false;

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Utilities/ProjectUtilities.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Utilities/ProjectUtilities.cs
@@ -10,7 +10,6 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Runtime.InteropServices;
     using EnvDTE;
     using Microsoft.VisualStudio;


### PR DESCRIPTION
Insulates the `IsProjectWebApp` from case issues with GUID strings by using converting to and comparing `Guid` types.

Add-on to #110.