### PR TITLE
Fix Transform whitespace handling

### DIFF
--- a/src/Microsoft.VisualStudio.SlowCheetah/Transformer/XmlTransformer.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah/Transformer/XmlTransformer.cs
@@ -137,13 +137,8 @@ namespace Microsoft.VisualStudio.SlowCheetah
             using (XmlTransformableDocument document = new XmlTransformableDocument())
             using (XmlTransformation transformation = new XmlTransformation(transformPath, this.logger))
             {
-                using (XmlTextReader reader = new XmlTextReader(sourcePath))
-                {
-                    reader.DtdProcessing = DtdProcessing.Ignore;
-
-                    document.PreserveWhitespace = true;
-                    document.Load(reader);
-                }
+                document.PreserveWhitespace = true;
+                document.Load(sourcePath);
 
                 var success = transformation.Apply(document);
 


### PR DESCRIPTION
XDT has it's own handling of whitespace and it seems to not work when reading from a stream. This causes #144. In that case, we can either:

1. Load directly from the file, allowing XDT to handle everything after that
2. Continue utilizing our own `XmlTextReader`. Right now, it would only be used to allow DTD processing
3. Create our own reader based on XDT's

Going with 1 with this PR since I'm not convinced of the benefits of using the XmlTextReader. 2 seems like very inconvenient for existing users. 3 would require a lot of (possibly) unnecessary work.