### PR TITLE
SlowCheetahTaskPath url format fix

### DIFF
--- a/src/Microsoft.VisualStudio.SlowCheetah/Build/Microsoft.VisualStudio.SlowCheetah.targets
+++ b/src/Microsoft.VisualStudio.SlowCheetah/Build/Microsoft.VisualStudio.SlowCheetah.targets
@@ -13,7 +13,7 @@ Copyright (C) Sayed Ibrahim Hashimi, Chuck England 2011-2013. All rights reserve
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <SlowCheetahTaskPath>$(MSBuildThisFileDirectory)..\tools\</SlowCheetahTaskPath>
+    <SlowCheetahTaskPath>$(MSBuildThisFileDirectory)\..\tools\</SlowCheetahTaskPath>
   </PropertyGroup>
 
   <!--Main transformation task-->


### PR DESCRIPTION
Missing backslash on the SlowCheetahTaskPath causes errors when building and transforming in with CLI or Microsoft,Build,Evaluation library.