### PR TITLE
Fix issue #166. Respect CopyToOutputDirectory value.

### DIFF
--- a/src/Microsoft.VisualStudio.SlowCheetah/Build/Microsoft.VisualStudio.SlowCheetah.targets
+++ b/src/Microsoft.VisualStudio.SlowCheetah/Build/Microsoft.VisualStudio.SlowCheetah.targets
@@ -89,7 +89,7 @@ Copyright (C) Sayed Ibrahim Hashimi, Chuck England 2011-2013. All rights reserve
         <DestinationFile Condition="'%(Link)' != ''">$(IntermediateOutputPath)%(Link)</DestinationFile>
         <TargetPath Condition="'%(Link)' != '' and '%(TargetPath)' == ''">%(Link)</TargetPath>
         <TargetPath Condition="'%(TargetPath)' == ''">%(RelativeDir)%(Filename)%(Extension)</TargetPath>
-        <CopyToOutputDirectory Condition=" '$(CopyToOutputDirectory)' == '' ">PreserveNewest</CopyToOutputDirectory>
+        <CopyToOutputDirectory Condition=" '$(CopyToOutputDirectory)' != '' ">$(CopyToOutputDirectory)</CopyToOutputDirectory>
       </ScFilesToTransform>
     </ItemGroup>
 


### PR DESCRIPTION
Previously, all transforms got copied into the OutputDirectory.  This update respects whatever setting is on the transform files.