### PR TITLE
Fix issue #166.

### DIFF
--- a/src/Microsoft.VisualStudio.SlowCheetah.Tests/BuildTests/TestProjects/ConsoleApp/ConsoleApp.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.Tests/BuildTests/TestProjects/ConsoleApp/ConsoleApp.csproj
@@ -67,6 +67,7 @@
     </None>
     <None Include="Other.config">
       <TransformOnBuild>true</TransformOnBuild>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>      
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Microsoft.VisualStudio.SlowCheetah.Tests/BuildTests/TestProjects/WebApplication/WebApplication.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.Tests/BuildTests/TestProjects/WebApplication/WebApplication.csproj
@@ -61,6 +61,7 @@
   <ItemGroup>
     <Content Include="Other.config">
       <TransformOnBuild>true</TransformOnBuild>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>      
     </Content>
     <Content Include="Other.Debug.config">
       <IsTransformItem>True</IsTransformItem>

--- a/src/Microsoft.VisualStudio.SlowCheetah/Build/Microsoft.VisualStudio.SlowCheetah.targets
+++ b/src/Microsoft.VisualStudio.SlowCheetah/Build/Microsoft.VisualStudio.SlowCheetah.targets
@@ -89,7 +89,7 @@ Copyright (C) Sayed Ibrahim Hashimi, Chuck England 2011-2013. All rights reserve
         <DestinationFile Condition="'%(Link)' != ''">$(IntermediateOutputPath)%(Link)</DestinationFile>
         <TargetPath Condition="'%(Link)' != '' and '%(TargetPath)' == ''">%(Link)</TargetPath>
         <TargetPath Condition="'%(TargetPath)' == ''">%(RelativeDir)%(Filename)%(Extension)</TargetPath>
-        <CopyToOutputDirectory Condition=" '$(CopyToOutputDirectory)' == '' ">PreserveNewest</CopyToOutputDirectory>
+        <CopyToOutputDirectory Condition=" '$(CopyToOutputDirectory)' != '' ">$(CopyToOutputDirectory)</CopyToOutputDirectory>
       </ScFilesToTransform>
     </ItemGroup>
 


### PR DESCRIPTION
The targets was always copying transformed files under the output folder. This update respects the CopyToOutputDirectory setting.