### PR TITLE
Fix Metadata error for some Item groups

### DIFF
--- a/src/Microsoft.VisualStudio.SlowCheetah/Build/Microsoft.VisualStudio.SlowCheetah.targets
+++ b/src/Microsoft.VisualStudio.SlowCheetah/Build/Microsoft.VisualStudio.SlowCheetah.targets
@@ -41,6 +41,12 @@ Copyright (C) Sayed Ibrahim Hashimi, Chuck England 2011-2013. All rights reserve
       <Link></Link>
       <CopyToOutputDirectory></CopyToOutputDirectory>
     </EmbeddedResource>
+    <_NoneWithTargetPath>
+      <TransformOnBuild>false</TransformOnBuild>
+    </_NoneWithTargetPath>
+    <ContentWithTargetPath>
+      <TransformOnBuild>false</TransformOnBuild>
+    </ContentWithTargetPath>
     <ScFilesToTransform>
       <_BuildAction></_BuildAction>
       <TargetPath></TargetPath>


### PR DESCRIPTION
Adding default value for TransformOnBuildMetadata to _NoneWithTargetPath and ContentWithTargetPath