### PR TITLE
Transition Nuget package logic in extension to async

### DIFF
--- a/src/Microsoft.VisualStudio.SlowCheetah.Tests/Microsoft.VisualStudio.SlowCheetah.Tests.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.Tests/Microsoft.VisualStudio.SlowCheetah.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS.Tests/Microsoft.VisualStudio.SlowCheetah.VS.Tests.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS.Tests/Microsoft.VisualStudio.SlowCheetah.VS.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Microsoft.VisualStudio.SlowCheetah.VS.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Microsoft.VisualStudio.SlowCheetah.VS.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <IsPackable>false</IsPackable>
     <Copyright>Copyright © Microsoft Corporation. All rights reserved.</Copyright>
     <CreateVsixContainer>false</CreateVsixContainer>

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/BackgroundInstallationHandler.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/BackgroundInstallationHandler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         public bool IsUpdate { get; set; } = false;
 
         /// <inheritdoc/>
-        public override void Execute(Project project)
+        public override async TPL.Task Execute(Project project)
         {
             string projName = project.UniqueName;
             bool needInstall = true;
@@ -47,18 +47,18 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
             {
                 string warningTitle = this.IsUpdate ? Resources.Resources.NugetUpdate_Title : Resources.Resources.NugetInstall_Title;
                 string warningMessage = this.IsUpdate ? Resources.Resources.NugetUpdate_Text : Resources.Resources.NugetInstall_Text;
-                if (this.HasUserAcceptedWarningMessage(warningTitle, warningMessage))
+                if (await this.HasUserAcceptedWarningMessage(warningTitle, warningMessage))
                 {
                     // Gets the general output pane to inform user of installation
-                    IVsOutputWindowPane outputWindow = (IVsOutputWindowPane)this.Package.GetService(typeof(SVsGeneralOutputWindowPane));
+                    IVsOutputWindowPane outputWindow = (IVsOutputWindowPane)await this.Package.GetServiceAsync(typeof(SVsGeneralOutputWindowPane));
                     outputWindow?.OutputString(string.Format(CultureInfo.CurrentCulture, Resources.Resources.NugetInstall_InstallingOutput, project.Name) + Environment.NewLine);
 
-                    TPL.Task.Run(() =>
+                    var task = this.Package.JoinableTaskFactory.RunAsync(async () =>
                     {
                         string outputMessage = Resources.Resources.NugetInstall_FinishedOutput;
                         try
                         {
-                            this.Successor.Execute(project);
+                            await this.Successor.Execute(project);
                         }
                         catch
                         {
@@ -72,7 +72,8 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
                                 InstallTasks.Remove(projName);
                             }
 
-                            ThreadHelper.Generic.BeginInvoke(() => outputWindow?.OutputString(string.Format(CultureInfo.CurrentCulture, outputMessage, project.Name) + Environment.NewLine));
+                            await this.Package.JoinableTaskFactory.SwitchToMainThreadAsync();
+                            outputWindow?.OutputString(string.Format(CultureInfo.CurrentCulture, outputMessage, project.Name) + Environment.NewLine);
                         }
                     });
                 }

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/BackgroundInstallationHandler.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/BackgroundInstallationHandler.cs
@@ -9,6 +9,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
     using EnvDTE;
     using Microsoft.VisualStudio.Shell;
     using Microsoft.VisualStudio.Shell.Interop;
+    using Microsoft.VisualStudio.Threading;
     using TPL = System.Threading.Tasks;
 
     /// <summary>
@@ -53,8 +54,10 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
                     IVsOutputWindowPane outputWindow = (IVsOutputWindowPane)await this.Package.GetServiceAsync(typeof(SVsGeneralOutputWindowPane));
                     outputWindow?.OutputString(string.Format(CultureInfo.CurrentCulture, Resources.Resources.NugetInstall_InstallingOutput, project.Name) + Environment.NewLine);
 
-                    var task = this.Package.JoinableTaskFactory.RunAsync(async () =>
+                    this.Package.JoinableTaskFactory.RunAsync(async () =>
                     {
+                        await TPL.TaskScheduler.Default;
+
                         string outputMessage = Resources.Resources.NugetInstall_FinishedOutput;
                         try
                         {
@@ -75,7 +78,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
                             await this.Package.JoinableTaskFactory.SwitchToMainThreadAsync();
                             outputWindow?.OutputString(string.Format(CultureInfo.CurrentCulture, outputMessage, project.Name) + Environment.NewLine);
                         }
-                    });
+                    }).Task.Forget();
                 }
                 else
                 {

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/BasePackageHandler.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/BasePackageHandler.cs
@@ -5,6 +5,8 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
 {
     using System;
     using EnvDTE;
+    using Microsoft.VisualStudio.Shell;
+    using TPL = System.Threading.Tasks;
 
     /// <summary>
     /// Handles a function relating to the NuGet package
@@ -29,7 +31,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         /// <summary>
         /// Gets the VS package
         /// </summary>
-        public IServiceProvider Package { get; }
+        public AsyncPackage Package { get; }
 
         /// <summary>
         /// Gets the successor handler
@@ -37,6 +39,6 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         protected IPackageHandler Successor { get; }
 
         /// <inheritdoc/>
-        public abstract void Execute(Project project);
+        public abstract TPL.Task Execute(Project project);
     }
 }

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/DialogInstallationHandler.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/DialogInstallationHandler.cs
@@ -5,6 +5,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
 {
     using EnvDTE;
     using Microsoft.VisualStudio.Shell.Interop;
+    using TPL = System.Threading.Tasks;
 
     /// <summary>
     /// Performs installations while showing a wait dialog
@@ -21,12 +22,12 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         }
 
         /// <inheritdoc/>
-        public override void Execute(Project project)
+        public override async TPL.Task Execute(Project project)
         {
-            if (this.HasUserAcceptedWarningMessage(Resources.Resources.NugetUpdate_Title, Resources.Resources.NugetUpdate_Text))
+            if (await this.HasUserAcceptedWarningMessage(Resources.Resources.NugetUpdate_Title, Resources.Resources.NugetUpdate_Text))
             {
                 // Creates dialog informing the user to wait for the installation to finish
-                IVsThreadedWaitDialogFactory twdFactory = this.Package.GetService(typeof(SVsThreadedWaitDialogFactory)) as IVsThreadedWaitDialogFactory;
+                IVsThreadedWaitDialogFactory twdFactory = await this.Package.GetServiceAsync(typeof(SVsThreadedWaitDialogFactory)) as IVsThreadedWaitDialogFactory;
                 IVsThreadedWaitDialog2 dialog = null;
                 twdFactory?.CreateInstance(out dialog);
 
@@ -36,7 +37,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
 
                 try
                 {
-                    this.Successor.Execute(project);
+                    await this.Successor.Execute(project);
                 }
                 finally
                 {

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/EmptyHandler.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/EmptyHandler.cs
@@ -5,6 +5,8 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
 {
     using System;
     using EnvDTE;
+    using Microsoft.VisualStudio.Shell;
+    using TPL = System.Threading.Tasks;
 
     /// <summary>
     /// An empty handler that performs no actions
@@ -15,18 +17,19 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         /// Initializes a new instance of the <see cref="EmptyHandler"/> class.
         /// </summary>
         /// <param name="package">VS package</param>
-        public EmptyHandler(IServiceProvider package)
+        public EmptyHandler(AsyncPackage package)
         {
             this.Package = package ?? throw new ArgumentNullException(nameof(package));
         }
 
         /// <inheritdoc/>
-        public IServiceProvider Package { get; }
+        public AsyncPackage Package { get; }
 
         /// <inheritdoc/>
-        public void Execute(Project project)
+        public TPL.Task Execute(Project project)
         {
             // Do nothing
+            return TPL.Task.FromResult(false);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/EmptyHandler.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/EmptyHandler.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         public TPL.Task Execute(Project project)
         {
             // Do nothing
-            return TPL.Task.FromResult(false);
+            return TPL.Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/IPackageHandler.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/IPackageHandler.cs
@@ -3,8 +3,9 @@
 
 namespace Microsoft.VisualStudio.SlowCheetah.VS
 {
-    using System;
     using EnvDTE;
+    using Microsoft.VisualStudio.Shell;
+    using TPL = System.Threading.Tasks;
 
     /// <summary>
     /// Representes a handler of nuget package actions
@@ -14,12 +15,13 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         /// <summary>
         /// Gets the VS package
         /// </summary>
-        IServiceProvider Package { get; }
+        AsyncPackage Package { get; }
 
         /// <summary>
         /// Executes the function
         /// </summary>
-        /// <param name="project">The project to act peform actions on</param>
-        void Execute(Project project);
+        /// <param name="project">The project to peform actions on</param>
+        /// <returns>A task that executes the function</returns>
+        TPL.Task Execute(Project project);
     }
 }

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/NuGetUninstaller.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/NuGetUninstaller.cs
@@ -5,7 +5,9 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
 {
     using EnvDTE;
     using Microsoft.VisualStudio.ComponentModelHost;
+    using Microsoft.VisualStudio.Shell;
     using NuGet.VisualStudio;
+    using TPL = System.Threading.Tasks;
 
     /// <summary>
     /// Uninstalls older versions of the SlowCheetah NuGet package
@@ -22,13 +24,13 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         }
 
         /// <inheritdoc/>
-        public override void Execute(Project project)
+        public override async TPL.Task Execute(Project project)
         {
-            var componentModel = (IComponentModel)this.Package.GetService(typeof(SComponentModel));
+            var componentModel = (IComponentModel)await this.Package.GetServiceAsync(typeof(SComponentModel));
             IVsPackageUninstaller packageUninstaller = componentModel.GetService<IVsPackageUninstaller>();
             packageUninstaller.UninstallPackage(project, SlowCheetahNuGetManager.OldPackageName, true);
 
-            this.Successor.Execute(project);
+            await this.Successor.Execute(project);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/NugetInstaller.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/NugetInstaller.cs
@@ -3,10 +3,8 @@
 
 namespace Microsoft.VisualStudio.SlowCheetah.VS
 {
-    using System;
     using EnvDTE;
     using Microsoft.VisualStudio.ComponentModelHost;
-    using Microsoft.VisualStudio.Shell;
     using NuGet.VisualStudio;
     using TPL = System.Threading.Tasks;
 

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/NugetInstaller.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/NugetInstaller.cs
@@ -6,7 +6,9 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
     using System;
     using EnvDTE;
     using Microsoft.VisualStudio.ComponentModelHost;
+    using Microsoft.VisualStudio.Shell;
     using NuGet.VisualStudio;
+    using TPL = System.Threading.Tasks;
 
     /// <summary>
     /// Installs the latest SlowCheetah NuGet package
@@ -23,9 +25,9 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         }
 
         /// <inheritdoc/>
-        public override void Execute(Project project)
+        public override async TPL.Task Execute(Project project)
         {
-            var componentModel = (IComponentModel)this.Package.GetService(typeof(SComponentModel));
+            var componentModel = (IComponentModel)await this.Package.GetServiceAsync(typeof(SComponentModel));
             IVsPackageInstaller packageInstaller = componentModel.GetService<IVsPackageInstaller>();
             packageInstaller.InstallPackage(
                 null,
@@ -34,7 +36,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
                 version: (string)null, // install latest stable version
                 ignoreDependencies: false);
 
-            this.Successor.Execute(project);
+            await this.Successor.Execute(project);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/TargetsUninstaller.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/TargetsUninstaller.cs
@@ -6,6 +6,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
     using System.Linq;
     using EnvDTE;
     using Microsoft.Build.Construction;
+    using TPL = System.Threading.Tasks;
 
     /// <summary>
     /// Uninstalls old SlowCheetah targets from the user's project file
@@ -22,10 +23,10 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         }
 
         /// <inheritdoc/>
-        public override void Execute(Project project)
+        public override async TPL.Task Execute(Project project)
         {
             // We handle any NuGet package logic before editing the project file
-            this.Successor.Execute(project);
+            await this.Successor.Execute(project);
 
             project.Save();
             ProjectRootElement projectRoot = ProjectRootElement.Open(project.FullName);

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/UserInstallationHandler.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/PackageHandlers/UserInstallationHandler.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.VisualStudio.SlowCheetah.VS
 {
     using System;
+    using System.Threading.Tasks;
     using Microsoft.VisualStudio;
     using Microsoft.VisualStudio.Shell.Interop;
 
@@ -27,9 +28,11 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         /// <param name="title">The title of the message box</param>
         /// <param name="message">The message to be shown</param>
         /// <returns>True if the user has accepted the warning message</returns>
-        protected bool HasUserAcceptedWarningMessage(string title, string message)
+        protected async Task<bool> HasUserAcceptedWarningMessage(string title, string message)
         {
-            if (this.Package.GetService(typeof(SVsUIShell)) is IVsUIShell shell)
+            var shell = (IVsUIShell)await this.Package.GetServiceAsync(typeof(SVsUIShell));
+
+            if (shell != null)
             {
                 // Show a yes or no message box with the given title and message
                 Guid compClass = Guid.Empty;

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/SlowCheetahNuGetManager.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/SlowCheetahNuGetManager.cs
@@ -52,13 +52,13 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
                 VsProjectTypes.ManagementPackProjectTypeGuid,
             };
 
-        private readonly IServiceProvider package;
+        private readonly AsyncPackage package;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SlowCheetahNuGetManager"/> class.
         /// </summary>
         /// <param name="package">VS Package</param>
-        public SlowCheetahNuGetManager(IServiceProvider package)
+        public SlowCheetahNuGetManager(AsyncPackage package)
         {
             this.package = package ?? throw new ArgumentNullException(nameof(package));
         }
@@ -162,7 +162,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
                 };
             }
 
-            plan.Execute(currentProject);
+            this.package.JoinableTaskFactory.Run(() => plan.Execute(currentProject));
         }
 
         private static IVsPackageInstallerServices GetInstallerServices(IServiceProvider package)

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/SlowCheetahNuGetManager.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/NugetHandler/SlowCheetahNuGetManager.cs
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
     using Microsoft.VisualStudio.Shell;
     using Microsoft.VisualStudio.Shell.Interop;
     using NuGet.VisualStudio;
+    using TPL = System.Threading.Tasks;
 
     /// <summary>
     /// Manages installations of the SlowCheetah NuGet package in the project
@@ -111,7 +112,8 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
         /// if an older version is detected, shows update information.
         /// </summary>
         /// <param name="hierarchy">Hierarchy of the project to be verified</param>
-        public void CheckSlowCheetahInstallation(IVsHierarchy hierarchy)
+        /// <returns>A <see cref="TPL.Task"/> representing the asynchronous operation.</returns>
+        public async TPL.Task CheckSlowCheetahInstallation(IVsHierarchy hierarchy)
         {
             if (hierarchy == null)
             {
@@ -162,7 +164,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
                 };
             }
 
-            this.package.JoinableTaskFactory.Run(() => plan.Execute(currentProject));
+            await plan.Execute(currentProject);
         }
 
         private static IVsPackageInstallerServices GetInstallerServices(IServiceProvider package)

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Package/AddTransformCommand.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Package/AddTransformCommand.cs
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
                 }
 
                 // Checks the SlowCheetah NuGet package installation
-                this.nuGetManager.CheckSlowCheetahInstallation(hierarchy);
+                this.package.JoinableTaskFactory.Run(() => this.nuGetManager.CheckSlowCheetahInstallation(hierarchy));
 
                 // need to enure that this item has metadata TransformOnBuild set to true
                 buildPropertyStorage.SetItemAttribute(itemid, SlowCheetahPackage.TransformOnBuild, "true");

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Package/PreviewTransformCommand.cs
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Package/PreviewTransformCommand.cs
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.SlowCheetah.VS
             }
 
             // Checks the SlowCheetah NuGet package installation
-            this.NuGetManager.CheckSlowCheetahInstallation(hierarchy);
+            this.Package.JoinableTaskFactory.Run(() => this.NuGetManager.CheckSlowCheetahInstallation(hierarchy));
 
             // Get the parent of the file to start searching for the source file
             ErrorHandler.ThrowOnFailure(hierarchy.GetProperty(itemId, (int)__VSHPROPID.VSHPROPID_Parent, out object parentIdObj));

--- a/src/Microsoft.VisualStudio.SlowCheetah.Vsix/Microsoft.VisualStudio.SlowCheetah.Vsix.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.Vsix/Microsoft.VisualStudio.SlowCheetah.Vsix.csproj
@@ -18,7 +18,7 @@
     <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{CD2AF93D-5714-404B-9D42-61477BE8F3CF}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>

--- a/src/Microsoft.VisualStudio.SlowCheetah.Vsix/source.extension.vsixmanifest
+++ b/src/Microsoft.VisualStudio.SlowCheetah.Vsix/source.extension.vsixmanifest
@@ -11,7 +11,7 @@
         <Tags>Transformations Transforms XML XDT JSON JDT</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/src/Microsoft.VisualStudio.SlowCheetah.Vsix/source.extension.vsixmanifest
+++ b/src/Microsoft.VisualStudio.SlowCheetah.Vsix/source.extension.vsixmanifest
@@ -11,7 +11,7 @@
         <Tags>Transformations Transforms XML XDT JSON JDT</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/src/Microsoft.VisualStudio.SlowCheetah/Microsoft.VisualStudio.SlowCheetah.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah/Microsoft.VisualStudio.SlowCheetah.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
We can no longer call GetService on a background thread, so transition the entire Nuget package logic to asynchronous logic.