### PR TITLE
Fix build pipeline

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -8,7 +8,7 @@ variables:
   NugetSecurityAnalysisWarningLevel: none # nuget.config requires signed packages by trusted owners
 
 queue:
-  name: VSEng-MicroBuildVS2019
+  name: VSEngSS-MicroBuild2019
   timeoutInMinutes: 60
 
 steps:
@@ -24,6 +24,9 @@ steps:
       }
 
       Write-Host "##vso[task.setvariable variable=feedGuid]$feedGuid"
+
+      $SkipPublishingNetworkArtifacts = 'true' ## Network artifacts not allowed on Scale Set Pool
+      Write-Host "##vso[task.setvariable variable=SkipPublishingNetworkArtifacts]$SkipPublishingNetworkArtifacts"
 
       if ($env:ComputerName.StartsWith('factoryvm', [StringComparison]::OrdinalIgnoreCase)) {
         Write-Host "Running on hosted queue"
@@ -122,6 +125,9 @@ steps:
     SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols
     SearchPattern: '**\*.pdb'
     SymbolServerType: TeamServices
+    ArtifactServices.Symbol.AccountName: microsoft
+    ArtifactServices.Symbol.PAT: $(System.AccessToken)
+    ArtifactServices.Symbol.UseAAD: false
   displayName: Archive symbols to VSTS
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['SignType'], 'real'))
 

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -4,6 +4,9 @@ trigger:
   paths:
     exclude: [".github", "doc", "*.md"]
 
+variables:
+  NugetSecurityAnalysisWarningLevel: none # nuget.config requires signed packages by trusted owners
+
 queue:
   name: VSEng-MicroBuildVS2017
   timeoutInMinutes: 60

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,8 +1,12 @@
 trigger:
   branches:
-    include: ["master"]
+    include:
+      - master
   paths:
-    exclude: [".github", "doc", "*.md"]
+    exclude: 
+      - .github
+      - doc
+      - '*.md'
 
 variables:
   NugetSecurityAnalysisWarningLevel: none # nuget.config requires signed packages by trusted owners

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -8,7 +8,7 @@ variables:
   NugetSecurityAnalysisWarningLevel: none # nuget.config requires signed packages by trusted owners
 
 queue:
-  name: VSEng-MicroBuildVS2017
+  name: VSEng-MicroBuildVS2019
   timeoutInMinutes: 60
 
 steps:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -139,15 +139,6 @@ steps:
   displayName: 'Publish Artifact: symbols'
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
-- task: ms-vscs-artifact.build-tasks.artifactSymbolTask-1.artifactSymbolTask@0
-  inputs:
-    symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
-    requestName: 'CollectionId/$(System.CollectionId)/ProjectId/$(System.TeamProjectId)/BuildId/$(Build.BuildId)'
-    sourcePath: '$(Build.ArtifactStagingDirectory)/symbols'
-    usePat: false
-  displayName: Publish Symbols to symweb
-  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['SignType'], 'real'))
-
 - task: CopyFiles@1
   displayName: Collecting packages
   inputs:

--- a/nuget.config
+++ b/nuget.config
@@ -2,10 +2,20 @@
 <configuration>
   <config>
     <add key="repositorypath" value="packages" />
+    <add key="signatureValidationMode" value="require" />
   </config>
   <packageSources>
     <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
   </packageSources>
+  <trustedSigners>
+    <repository name="nuget" serviceIndex="https://api.nuget.org/v3/index.json">
+      <owners>Microsoft;xunit;aarnott;jkeech;sharwell;jamesnk</owners>
+      <certificate fingerprint="0e5f38f57dc1bcc806d8494f4f90fbcedd988b46760709cbeec6f4219aa6157d" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+    </repository>
+    <author name="Microsoft">
+      <certificate fingerprint="aa12da22a49bce7d5c1ae64cc1f3d892f150da76140f210abd2cbffca2c18a27" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+    </author>
+  </trustedSigners>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -4,7 +4,8 @@
     <add key="repositorypath" value="packages" />
   </config>
   <packageSources>
+    <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="vs-devcore" value="https://www.myget.org/F/vs-devcore/api/v3/index.json" />
+    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Microsoft.VisualStudio.SlowCheetah.Tests/Microsoft.VisualStudio.SlowCheetah.Tests.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.Tests/Microsoft.VisualStudio.SlowCheetah.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MicroBuild.NonShipping" Version="2.0.54" />
+    <PackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild" Version="2.0.66" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS.Tests/Microsoft.VisualStudio.SlowCheetah.VS.Tests.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS.Tests/Microsoft.VisualStudio.SlowCheetah.VS.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MicroBuild.NonShipping" Version="2.0.54" />
+    <PackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild" Version="2.0.66" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Microsoft.VisualStudio.SlowCheetah.VS.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Microsoft.VisualStudio.SlowCheetah.VS.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="EnvDTE" Version="8.0.1" />
-    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.54" />
+    <PackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="2.0.66" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="14.0.25424" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="14.1.2" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.14.0" Version="14.0.23205" />

--- a/src/Microsoft.VisualStudio.SlowCheetah.Vsix/Microsoft.VisualStudio.SlowCheetah.Vsix.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.Vsix/Microsoft.VisualStudio.SlowCheetah.Vsix.csproj
@@ -73,7 +73,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.54" />
+    <PackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="2.0.66" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.1.192" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.30" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.SlowCheetah.Vsix/Microsoft.VisualStudio.SlowCheetah.Vsix.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.Vsix/Microsoft.VisualStudio.SlowCheetah.Vsix.csproj
@@ -20,6 +20,7 @@
     <OutputType>Library</OutputType>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
+    <CreateVsixContainer>true</CreateVsixContainer>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>

--- a/src/Microsoft.VisualStudio.SlowCheetah/Microsoft.VisualStudio.SlowCheetah.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah/Microsoft.VisualStudio.SlowCheetah.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.54" />
+    <PackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="2.0.66" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="14.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Jdt" Version="0.9.23" />
     <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.1" />


### PR DESCRIPTION
Updating the build pipeline to meet the latest security requirements:
- Removing dependency on myget feed
- Consuming signed packages by approved owners
- Moving to scaleset pool
- Fixing the build getting stuck while trying to deploy the vsix to Visual Studio