### PR TITLE
updating newtonsoft version

### DIFF
--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Microsoft.VisualStudio.SlowCheetah.VS.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Microsoft.VisualStudio.SlowCheetah.VS.csproj
@@ -15,8 +15,7 @@
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" />
     <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Jdt" Version="0.9.23" />
+    <PackageReference Include="Microsoft.VisualStudio.Jdt" Version="0.9.63" />
     <PackageReference Include="NuGet.VisualStudio" Version="5.11.0" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.30" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="all" />


### PR DESCRIPTION
There are vulnerabilities for newtonsoft, so updating the version of JDT that pulls in bad reference.