### PR TITLE
reverting update to SDK to enable older versions of VS

### DIFF
--- a/src/Microsoft.VisualStudio.SlowCheetah.VS/Microsoft.VisualStudio.SlowCheetah.VS.csproj
+++ b/src/Microsoft.VisualStudio.SlowCheetah.VS/Microsoft.VisualStudio.SlowCheetah.VS.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.6.36389" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" />
     <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Jdt" Version="0.9.63" />
     <PackageReference Include="NuGet.VisualStudio" Version="17.6.0" />


### PR DESCRIPTION
Updating Microsoft.VisualStudio.SDK caused older versions to not be able to use Slowcheetah. Reverted that update to enable earlier versions to work.