### PR TITLE
Updating slowcheetah to use microbuild archiving.

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -218,15 +218,12 @@ extends:
               !**/*Test*
             TargetFolder: $(Build.ArtifactStagingDirectory)/symbols
           condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-        - task: PublishSymbols@2
+
+        - task: MicroBuildArchiveSymbols@5
+          displayName: 🔣 Archive symbols to Symweb
           inputs:
-            SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols
-            SearchPattern: '**\*.pdb'
-            SymbolServerType: TeamServices
-            ArtifactServices.Symbol.AccountName: microsoft
-            ArtifactServices.Symbol.PAT: $(System.AccessToken)
-            ArtifactServices.Symbol.UseAAD: false
-          displayName: Archive symbols to VSTS
+            SymbolsFeatureName: $(SymbolsFeatureName)
+            SymbolsProject: VS
           condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['SignType'], 'real'))
         - task: CopyFiles@1
           displayName: Collecting packages


### PR DESCRIPTION
I removed the publish symbols task because the only resason for the task according to email chain is to index. However, for git repos this has been a longstanding issue that never works. So we only need to use the new microbuildarchiving task.

https://github.com/microsoft/azure-pipelines-tasks/issues/15605