### PR TITLE
Bump .NET SDK to 9.0.312

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.311",
+    "version": "9.0.312",
     "rollForward": "patch",
     "allowPrerelease": false
   },


### PR DESCRIPTION
Update .NET SDK version to 9.0.312 in global.json

Updated global.json to use .NET SDK version 9.0.312 instead of 9.0.311 to ensure compatibility with the latest patch release. No other changes were made.